### PR TITLE
Fix C++ build error: Add boost-devel to makedepends

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/lion-lef/nekobox-void/issues/5
-Your prepared branch: issue-5-52c497bdd383
-Your prepared working directory: /tmp/gh-issue-solver-1768754644552
-Your forked repository: konard/lion-lef-nekobox-void
-Original repository (upstream): lion-lef/nekobox-void
-
-Proceed.


### PR DESCRIPTION
## Summary

This PR fixes the C++ build error in GitHub Actions by adding `boost-devel` to the `makedepends` in the nekobox package template.

## Problem

The build was failing with the following error across all architectures (x86_64, x86_64-musl):

```
/usr/include/thrift/transport/TTransportException.h:23:10: fatal error: 
boost/numeric/conversion/cast.hpp: No such file or directory
   23 | #include <boost/numeric/conversion/cast.hpp>
```

## Root Cause Analysis

1. The `thrift-devel` package was listed in `makedepends`, which is correct
2. However, thrift's header files (`TTransportException.h`) include Boost headers (`boost/numeric/conversion/cast.hpp`)
3. The official [void-packages thrift template](https://github.com/void-linux/void-packages/blob/master/srcpkgs/thrift/template) includes `boost-devel-minimal` and other boost libraries in its makedepends
4. When thrift-devel is used as a dependency in another package, those Boost headers must also be available at build time
5. Our template was missing `boost-devel`, causing the compilation to fail

## Solution

Added `boost-devel` to the `makedepends` line in `srcpkgs/nekobox/template`:

```diff
-makedepends="qt6-base-devel qt6-declarative-devel thrift-devel openssl-devel"
+makedepends="qt6-base-devel qt6-declarative-devel thrift-devel openssl-devel boost-devel"
```

## Changes Made

- **File modified:** `srcpkgs/nekobox/template`
- **Change:** Added `boost-devel` to the `makedepends` list at line 21

## Testing

The fix addresses the specific compiler error found in CI logs (run #21115031093) where the Thrift headers required Boost headers that were not available.

Since the workflow is configured to run only on tag pushes and manual dispatch (not on branch pushes), the CI won't run automatically on this branch. To test this fix:
- A manual workflow dispatch can be triggered, or
- The fix can be merged and tested on the next tag push

## References

- Fixes #5
- CI log analysis: `/usr/include/thrift/transport/TTransportException.h:23:10` requires `boost/numeric/conversion/cast.hpp`
- Upstream thrift package: Uses `boost-devel-minimal` and boost libraries in makedepends

---
*This PR was created by the AI issue solver*