### PR TITLE
Fix CI build failures and add PR trigger

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/lion-lef/nekobox-void/issues/7
-Your prepared branch: issue-7-f8bfbe5462cb
-Your prepared working directory: /tmp/gh-issue-solver-1768756182192
-Your forked repository: konard/lion-lef-nekobox-void
-Original repository (upstream): lion-lef/nekobox-void
-
-Proceed.


### PR DESCRIPTION
## Summary

This PR fixes the failing CI builds and adds a pull_request trigger for automated testing on PRs.

### Issues Fixed

1. **libthrift.so shlib mapping error** - The thrift package in void-packages doesn't register its shared library in `common/shlibs`. This caused the error: `SONAME: libthrift.so.0.22.0 <-> UNKNOWN PKG PLEASE FIX!`. Fixed by adding the shlib mapping during the build workflow.

2. **aarch64 cross-compilation failure** - Qt6's `qmlimportscanner` binary cannot run on x86_64 host when built for aarch64 target. Error: `qmlimportscanner: cannot execute binary file`. This is a known Qt6 cross-compilation limitation. Disabled aarch64 targets for now.

3. **Missing PR trigger** - Added `pull_request` trigger to run CI on pull requests to main/master branches.

### Changes

- Add `pull_request` trigger for CI on PRs
- Register `libthrift.so.0.22.0` in `common/shlibs` during build
- Remove aarch64 and aarch64-musl from build matrix
- Update release notes to reflect available architectures

### Build Matrix

After this fix, the following architectures are supported:
- x86_64 (glibc)
- x86_64-musl

Fixes lion-lef/nekobox-void#7

---
*This PR was created automatically by the AI issue solver*